### PR TITLE
Fixes #17 - more Ubuntu-y DNS configuration

### DIFF
--- a/install-linux-vcair-example.sh
+++ b/install-linux-vcair-example.sh
@@ -14,6 +14,9 @@ fi
 
 if test "$platform" = "ubuntu"; then
         sed -i 's/PasswordAuthentication no/PasswordAuthentication yes/g' /etc/ssh/sshd_config
+        sed -i 's/dns.*/dns-nameservers 8.8.8.8 8.8.4.4/g' /etc/network/interfaces
 fi
 
-echo -e "nameserver 8.8.8.8\nnameserver 8.8.4.4" >> /etc/resolv.conf
+if test "$platform" = "centos"; then
+	printf "nameserver 8.8.8.8\nnameserver 8.8.4.4" >> /etc/resolv.conf
+fi


### PR DESCRIPTION
- use Ubuntu specific mechanism for DNS
- use `printf` instead of `echo -e`. Because portability.
