### PR TITLE
Adding support for vCloud Air OnDemand.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ easiest way to accomplish this is to create these entries in your
 If your knife.rb file will be checked into a SCM system (ie readable
 by others) you may want to read the values from environment variables.
 
-    knife[:vcair_api_host] = "#{ENV['VCAIR_API_URL']}"
-    knife[:vcair_username] = "#{ENV['VCAIR_USERNAME']}"
-    knife[:vcair_password] = "#{ENV['VCAIR_PASSWORD']}"
-    knife[:vcair_org] = "#{ENV['VCAIR_ORG']}"
+    knife[:vcair_api_host] = ENV['VCAIR_API_URL']
+    knife[:vcair_username] = ENV['VCAIR_USERNAME']
+    knife[:vcair_password] = ENV['VCAIR_PASSWORD']
+    knife[:vcair_org] = ENV['VCAIR_ORG']
 
 ## VMware vCloud Air - Subscription ##
 

--- a/README.md
+++ b/README.md
@@ -7,19 +7,6 @@ Please refer to the [CHANGELOG](CHANGELOG.md) for version history and known issu
 
 # Installation #
 
-## Current Source Build Instructions: ##
-
-Then build and install this gem, run:
-
-    $ gem build knife-vcair.gemspec
-    $ gem install knife-vcair-0.6.X.gem
-
-or if you are using the Chef Development Kit (Chef DK), to install it run:
-
-    $ chef gem install knife-vcair-0.X.0.gem
-
-## Future Rubygems Instructions: ##
-
 This plugin is distributed as a Ruby Gem. To install it, run:
 
     $ gem install knife-vcair
@@ -48,7 +35,7 @@ by others) you may want to read the values from environment variables.
     knife[:vcair_password] = "#{ENV['VCAIR_PASSWORD']}"
     knife[:vcair_org] = "#{ENV['VCAIR_ORG']}"
 
-## VMware's vcair ##
+## VMware vCloud Air - Subscription ##
 
 If you are using VMware's hosted vcair the API URL is found by logging
 into the https://vchs.vmware.com, and clicking on your Dashboard's
@@ -64,6 +51,22 @@ https://vchs.vmware.com login, giving us the values:
     knife[:vcair_username] = 'user@somedomain.com
     knife[:vcair_password] = 'VCAIRSECRET'
     knife[:vcair_org] = 'M511664989-4904'
+
+## VMware vCloud Air - OnDemand ##
+
+Your Org ID is commonly a UUID-formatted string and can be found in the URL
+after you log in to vCloud Air OnDemand (for example:
+https://us-virginia-1-4....?orgName=SOME_UUID_HERE) or it will be displayed
+next to your name in the upper-left corner of the vCloud Director web UI.  You
+can also ascertain your Org ID by following [these instructions](http://pubs.vmware.com/vca/index.jsp#com.vmware.vcloud.api.tenant.doc_511/GUID-D902143B-CF49-4508-99CA-2715B448F5E8.html).
+
+Additionally, you will need to override the API path as the API path between
+the subscription service and the OnDemand service are different.  You will need
+to set the following entry in your `knife.rb` file:
+
+    knife[:vcair_api_path] = '/api/compute/api'
+
+... or you may pass it in on the CLI using `--vcair-api-path`.
 
 # knife vcair subcommands #
 

--- a/lib/chef/knife/cloud/vcair_service.rb
+++ b/lib/chef/knife/cloud/vcair_service.rb
@@ -27,6 +27,7 @@ class Chef
           Chef::Log.debug("vcair_username #{Chef::Config[:knife][:vcair_username]}")
           Chef::Log.debug("vcair_org #{Chef::Config[:knife][:vcair_org]}")
           Chef::Log.debug("vcair_api_host #{Chef::Config[:knife][:vcair_api_host]}")
+          Chef::Log.debug("vcair_api_path #{Chef::Config[:knife][:vcair_api_path]}")
           Chef::Log.debug("vcair_api_version #{Chef::Config[:knife][:vcair_api_version]}")
           Chef::Log.debug("vcair_show_progress #{Chef::Config[:knife][:vcair_show_progress]}")
 
@@ -42,7 +43,8 @@ class Chef
               :vcloud_director_password => Chef::Config[:knife][:vcair_password],
               :vcloud_director_host => Chef::Config[:knife][:vcair_api_host],
               :vcloud_director_api_version => Chef::Config[:knife][:vcair_api_version],
-              :vcloud_director_show_progress => false
+              :vcloud_director_show_progress => false,
+              :path => Chef::Config[:knife][:vcair_api_path]
             }
           }))
         end
@@ -50,7 +52,6 @@ class Chef
         def add_api_endpoint
           @auth_params.merge!({:vcair_api_host => Chef::Config[:knife][:vcair_api_host]}) unless Chef::Config[:knife][:api_endpoint].nil?
         end
-
       end
     end
   end

--- a/lib/chef/knife/cloud/vcair_service_options.rb
+++ b/lib/chef/knife/cloud/vcair_service_options.rb
@@ -39,7 +39,12 @@ class Chef
            :long => "--vcair-api-host HOST",
            :description => "The VCAIR API endpoint",
            :proc => Proc.new { |u| Chef::Config[:knife][:vcair_api_host] = u }
-           
+
+           option :vcair_api_path,
+           :long => '--vcair-api-path PATH',
+           :description => 'The API service endpoint path, if different from the default "/api"',
+           :proc => Proc.new { |path| Chef::Config[:knife][:vcair_api_path] = path}
+
            option :vcair_org,
            :short => "-O ORG",
            :long => "--vcair-org ORG",
@@ -68,7 +73,7 @@ class Chef
            :long => "--vcair-show-progress BOOL",
            :description => "Show VCAIR API Progress",
            :default => false
-           
+
           end
         end
       end


### PR DESCRIPTION
The API path is different between Subscription and OnDemand.  Specifically,
in Subscription it's '/api' while in OnDemand it's '/api/compute/api'.

The Fog gem supports a path override, but knife-vcair did not support
collecting and passing the path override.  This commit addresses that issue.

Addresses the issue reported in #28.